### PR TITLE
Prevent special headers from affecting recorded responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1
+	github.com/go-chi/cors v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20200511160909-eb529947af53
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chi/cors v1.2.0 h1:tV1g1XENQ8ku4Bq3K9ub2AtgG+p16SmzeMSGTwrOKdE=
+github.com/go-chi/cors v1.2.0/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/hashicorp/golang-lru v0.5.5-0.20200511160909-eb529947af53 h1:mcyf48FjrlX8JRXvy5v3LPeXBv+Um6WvoKS+kknfgIk=
 github.com/hashicorp/golang-lru v0.5.5-0.20200511160909-eb529947af53/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/http.go
+++ b/http.go
@@ -92,9 +92,7 @@ func HandlerWithKey(cacheSize int, ttl time.Duration, keyFunc ...func(r *http.Re
 			// process request (single flight)
 			val, err := cache.GetFresh(r.Context(), key, func(ctx context.Context) (interface{}, error) {
 				first = true
-
 				buf := bytes.NewBuffer(nil)
-
 				ww := &responseWriter{ResponseWriter: w, tee: buf}
 
 				next.ServeHTTP(ww, r)

--- a/stampede_test.go
+++ b/stampede_test.go
@@ -140,10 +140,7 @@ func TestHandler(t *testing.T) {
 				t.Error("expecting response status:", expectedStatus)
 			}
 
-			if resp.Header.Get("X-Httpjoin") != "test" {
-				t.Error("expecting x-httpjoin test header")
-			}
-
+			assert.Equal(t, "test", resp.Header.Get("X-Httpjoin"), "expecting x-httpjoin test header")
 		}()
 	}
 
@@ -178,6 +175,7 @@ func TestIssue6_BypassCORSHeaders(t *testing.T) {
 
 	app := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "example.com")
+		w.Header().Set("X-Another-Header", "wakka")
 		w.WriteHeader(expectedStatus)
 		w.Write(expectedBody)
 	}
@@ -213,6 +211,7 @@ func TestIssue6_BypassCORSHeaders(t *testing.T) {
 			}
 
 			assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+			assert.Equal(t, "wakka", resp.Header.Get("X-Another-Header"))
 		}()
 	}
 


### PR DESCRIPTION
This PR adds a routine that prevents recorded headers from affecting recorded responses. This is useful when we want to record a CORS-affected request but we don't want to repeat the exact same headers to all clients (each client may have a different `Origin`).

Closes https://github.com/go-chi/stampede/issues/6