### PR TITLE
Fix error on writeless handle

### DIFF
--- a/http.go
+++ b/http.go
@@ -23,7 +23,7 @@ var stripOutHeaders = []string{
 }
 
 func Handler(cacheSize int, ttl time.Duration, paths ...string) func(next http.Handler) http.Handler {
-	keyFunc := func(r *http.Request) uint64 {
+	defaultKeyFunc := func(r *http.Request) uint64 {
 		// Read the request payload, and then setup buffer for future reader
 		var buf []byte
 		if r.Body != nil {
@@ -36,6 +36,10 @@ func Handler(cacheSize int, ttl time.Duration, paths ...string) func(next http.H
 		return key
 	}
 
+	return HandlerWithKey(cacheSize, ttl, defaultKeyFunc, paths...)
+}
+
+func HandlerWithKey(cacheSize int, ttl time.Duration, keyFunc func(r *http.Request) uint64, paths ...string) func(next http.Handler) http.Handler {
 	// mapping of url paths that are cacheable by the stampede handler
 	pathMap := map[string]struct{}{}
 	for _, path := range paths {
@@ -49,7 +53,7 @@ func Handler(cacheSize int, ttl time.Duration, paths ...string) func(next http.H
 	// executes, and the remaining handlers will use the response from
 	// the first request. The content thereafter will be cached for up to
 	// ttl time for subsequent requests for further caching.
-	h := HandlerWithKey(cacheSize, ttl, keyFunc)
+	h := stampede(cacheSize, ttl, keyFunc)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -72,30 +76,30 @@ func Handler(cacheSize int, ttl time.Duration, paths ...string) func(next http.H
 	}
 }
 
-func HandlerWithKey(cacheSize int, ttl time.Duration, keyFunc ...func(r *http.Request) uint64) func(next http.Handler) http.Handler {
+func stampede(cacheSize int, ttl time.Duration, keyFunc func(r *http.Request) uint64) func(next http.Handler) http.Handler {
 	cache := NewCache(cacheSize, ttl, ttl*2)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 			// cache key for the request
-			var key uint64
-			if len(keyFunc) > 0 {
-				key = keyFunc[0](r)
-			} else {
-				key = StringToHash(r.Method, strings.ToLower(r.URL.Path))
-			}
+			key := keyFunc(r)
 
 			// mark the request that actually processes the response
-			first := false
+			first := true
 
 			// process request (single flight)
 			val, err := cache.GetFresh(r.Context(), key, func(ctx context.Context) (interface{}, error) {
-				first = true
 				buf := bytes.NewBuffer(nil)
 				ww := &responseWriter{ResponseWriter: w, tee: buf}
 
 				next.ServeHTTP(ww, r)
+
+				// the handler may not write header and body in some logic,
+				// while writing only the body, an attempt is made to write the default header (http.StatusOK)
+				if ww.IsHeaderWrote() {
+					first = false
+				}
 
 				val := responseValue{
 					headers: ww.Header(),
@@ -165,6 +169,10 @@ func (b *responseWriter) WriteHeader(code int) {
 		b.wroteHeader = true
 		b.ResponseWriter.WriteHeader(code)
 	}
+}
+
+func (b *responseWriter) IsHeaderWrote() bool {
+	return b.wroteHeader
 }
 
 func (b *responseWriter) Write(buf []byte) (int, error) {

--- a/stampede_test.go
+++ b/stampede_test.go
@@ -248,3 +248,39 @@ func TestIssue6_BypassCORSHeaders(t *testing.T) {
 	// expect to have only one actual hit
 	assert.Equal(t, uint64(1), count)
 }
+
+func TestPanic(t *testing.T) {
+	mux := http.NewServeMux()
+	middleware := stampede.Handler(100, 1*time.Hour)
+	mux.Handle("/", middleware(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		t.Log(r.Method, r.URL)
+	})))
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	{
+		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		t.Log(resp.StatusCode)
+	}
+	{
+		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		t.Log(resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Fix error occurs if an empty handler that does not write a status code