### PR TITLE
[ONLY EXAMPLE] Memory leak problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ prevent a stampede scenario on your handler.
 to not include anything sensitive or user specific. In the case you require user-specific
 stampede handlers, make sure you pass a custom `keyFunc` to the `stampede.Handler` and
 split the cache by an account's id.
+See [example](_example/with-key.go) for a variety of examples.
 
 
 ## LICENSE

--- a/_example/with-key.go
+++ b/_example/with-key.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"github.com/cespare/xxhash/v2"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/stampede"
 )
@@ -71,7 +69,7 @@ func main() {
 	// Include anything sensitive or user specific, e.g. Authorization Token
 	customKeyFunc := func(r *http.Request) uint64 {
 		token := r.Header.Get("Authorization")
-		return StringToHash(r.Method, strings.ToLower(strings.ToLower(token)))
+		return stampede.StringToHash(r.Method, strings.ToLower(strings.ToLower(token)))
 	}
 	cached := stampede.HandlerWithKey(512, 1*time.Second, customKeyFunc)
 
@@ -84,12 +82,4 @@ func main() {
 	})
 
 	http.ListenAndServe(":3333", r)
-}
-
-func StringToHash(s ...string) uint64 {
-	d := xxhash.New()
-	for _, v := range s {
-		d.WriteString(v)
-	}
-	return d.Sum64()
 }

--- a/_example/with-key.go
+++ b/_example/with-key.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"github.com/cespare/xxhash/v2"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/stampede"
+)
+
+/**
+Example 1: Make two parallel requests:
+	First request in first client:
+		GET http://localhost:3333/me
+		Authorization: Bar
+
+	Second request in second client:
+		GET http://localhost:3333/me
+		Authorization: Bar
+
+	-> Result of both queries in one time:
+			HTTP/1.1 200 OK
+			Content-Length: 14
+			Content-Type: text/plain; charset=utf-8
+
+			Bearer BarTone
+
+			Response code: 200 (OK); Time: 1ms; Content length: 14 bytes
+
+---------------------------------------------------------------
+
+Example 2: Make two parallel requests:
+	First request in first client:
+		GET http://localhost:3333/me
+		Authorization: Bar
+
+	Second request in second client:
+		GET http://localhost:3333/me
+		Authorization: Foo
+
+	-> Result of first:
+			HTTP/1.1 200 OK
+			Content-Length: 14
+			Content-Type: text/plain; charset=utf-8
+
+			Bearer Bar
+
+			Response code: 200 (OK); Time: 1ms; Content length: 14 bytes
+
+	-> Result of second:
+			HTTP/1.1 200 OK
+			Content-Length: 14
+			Content-Type: text/plain; charset=utf-8
+
+			Bearer Foo
+
+			Response code: 200 (OK); Time: 1ms; Content length: 14 bytes
+*/
+func main() {
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("index"))
+	})
+
+	// Include anything sensitive or user specific, e.g. Authorization Token
+	customKeyFunc := func(r *http.Request) uint64 {
+		token := r.Header.Get("Authorization")
+		return StringToHash(r.Method, strings.ToLower(strings.ToLower(token)))
+	}
+	cached := stampede.HandlerWithKey(512, 1*time.Second, customKeyFunc)
+
+	r.With(cached).Get("/me", func(w http.ResponseWriter, r *http.Request) {
+		// processing..
+		time.Sleep(3 * time.Second)
+
+		w.WriteHeader(200)
+		w.Write([]byte(r.Header.Get("Authorization")))
+	})
+
+	http.ListenAndServe(":3333", r)
+}
+
+func StringToHash(s ...string) uint64 {
+	d := xxhash.New()
+	for _, v := range s {
+		d.WriteString(v)
+	}
+	return d.Sum64()
+}

--- a/_example/with-key.go
+++ b/_example/with-key.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/stampede"
 )

--- a/stampede.go
+++ b/stampede.go
@@ -32,6 +32,10 @@ type Cache struct {
 	callGroup singleflight.Group
 }
 
+func (c *Cache) Flush() *lru.Cache {
+	return c.values
+}
+
 func (c *Cache) Get(ctx context.Context, key interface{}, fn func(ctx context.Context) (interface{}, error)) (interface{}, error) {
 	return c.get(ctx, key, false, fn)
 }

--- a/stampede.go
+++ b/stampede.go
@@ -123,3 +123,11 @@ func BytesToHash(b ...[]byte) uint64 {
 	}
 	return d.Sum64()
 }
+
+func StringToHash(s ...string) uint64 {
+	d := xxhash.New()
+	for _, v := range s {
+		d.WriteString(v)
+	}
+	return d.Sum64()
+}

--- a/stampede.go
+++ b/stampede.go
@@ -123,11 +123,3 @@ func BytesToHash(b ...[]byte) uint64 {
 	}
 	return d.Sum64()
 }
-
-func StringToHash(s ...string) uint64 {
-	d := xxhash.New()
-	for _, v := range s {
-		d.WriteString(v)
-	}
-	return d.Sum64()
-}

--- a/stampede_leak_test.go
+++ b/stampede_leak_test.go
@@ -1,0 +1,55 @@
+package stampede_test
+
+import (
+	"fmt"
+	"github.com/go-chi/stampede"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestMemoryLeak(t *testing.T) {
+	mux := http.NewServeMux()
+	respRec := httptest.NewRecorder()
+
+	cacheTime := 2 * time.Second
+	cache := stampede.NewCache(100, cacheTime, 2*cacheTime)
+
+	s := stampede.NewM()
+	s.SetCache(cache)
+	h := s.Handler(100, cacheTime)
+
+	n := 10
+	for i := 1; i <= n; i++ {
+		mux.Handle("/cached-"+strconv.Itoa(i), h(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Write([]byte(fmt.Sprintf("%v %v \n", "Handled route: ", r.URL.Path)))
+		})))
+	}
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	count := 0
+	for i := 1; i <= n; i++ {
+		{
+			url := "/cached-" + strconv.Itoa(i)
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			mux.ServeHTTP(respRec, req)
+			count = count + 1
+		}
+	}
+
+	assert.Equal(t, 10, count, "count of call")
+
+	time.Sleep(cacheTime * 3)
+	leakCnt := cache.Flush().Len()
+
+	assert.Equal(t, 0, leakCnt, "leaked values")
+}

--- a/stampede_test.go
+++ b/stampede_test.go
@@ -163,6 +163,9 @@ func TestHandler(t *testing.T) {
 func TestHash(t *testing.T) {
 	h1 := stampede.BytesToHash([]byte{1, 2, 3})
 	assert.Equal(t, uint64(8376154270085342629), h1)
+
+	h2 := stampede.StringToHash("123")
+	assert.Equal(t, uint64(4353148100880623749), h2)
 }
 
 func TestIssue6_BypassCORSHeaders(t *testing.T) {

--- a/stampede_test.go
+++ b/stampede_test.go
@@ -163,9 +163,6 @@ func TestHandler(t *testing.T) {
 func TestHash(t *testing.T) {
 	h1 := stampede.BytesToHash([]byte{1, 2, 3})
 	assert.Equal(t, uint64(8376154270085342629), h1)
-
-	h2 := stampede.StringToHash("123")
-	assert.Equal(t, uint64(4353148100880623749), h2)
 }
 
 func TestIssue6_BypassCORSHeaders(t *testing.T) {

--- a/stampede_test.go
+++ b/stampede_test.go
@@ -1,250 +1,251 @@
 package stampede_test
 
-import (
-	"context"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"net/http/httptest"
-	"runtime"
-	"sync"
-	"sync/atomic"
-	"testing"
-	"time"
-
-	"github.com/go-chi/cors"
-	"github.com/go-chi/stampede"
-	"github.com/stretchr/testify/assert"
-)
-
-func TestGet(t *testing.T) {
-	var count uint64
-	cache := stampede.NewCache(512, time.Duration(2*time.Second), time.Duration(5*time.Second))
-
-	// repeat test multiple times
-	for x := 0; x < 5; x++ {
-		// time.Sleep(1 * time.Second)
-
-		var wg sync.WaitGroup
-		numGoroutines := runtime.NumGoroutine()
-
-		n := 10
-		ctx := context.Background()
-
-		for i := 0; i < n; i++ {
-			t.Logf("numGoroutines now %d", runtime.NumGoroutine())
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
-				val, err := cache.Get(ctx, "t1", func(ctx context.Context) (interface{}, error) {
-					t.Log("cache.Get(t1, ...)")
-
-					// some extensive op..
-					time.Sleep(2 * time.Second)
-					atomic.AddUint64(&count, 1)
-
-					return "result1", nil
-				})
-
-				assert.NoError(t, err)
-				assert.Equal(t, "result1", val)
-			}()
-		}
-
-		wg.Wait()
-
-		// ensure single call
-		assert.Equal(t, uint64(1), count)
-
-		// confirm same before/after num of goroutines
-		t.Logf("numGoroutines now %d", runtime.NumGoroutine())
-		assert.Equal(t, numGoroutines, runtime.NumGoroutine())
-
-	}
-}
-
-func TestHandler(t *testing.T) {
-	var numRequests = 30
-
-	var hits uint32
-	var expectedStatus int = 201
-	var expectedBody = []byte("hi")
-
-	app := func(w http.ResponseWriter, r *http.Request) {
-		// log.Println("app handler..")
-
-		atomic.AddUint32(&hits, 1)
-
-		hitsNow := atomic.LoadUint32(&hits)
-		if hitsNow > 1 {
-			// panic("uh oh")
-		}
-
-		// time.Sleep(100 * time.Millisecond) // slow handler
-		w.Header().Set("X-Httpjoin", "test")
-		w.WriteHeader(expectedStatus)
-		w.Write(expectedBody)
-	}
-
-	var count uint32
-	counter := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddUint32(&count, 1)
-			next.ServeHTTP(w, r)
-			atomic.AddUint32(&count, ^uint32(0))
-			// log.Println("COUNT:", atomic.LoadUint32(&count))
-		})
-	}
-
-	recoverer := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			defer func() {
-				if r := recover(); r != nil {
-					log.Println("recovered panicing request:", r)
-				}
-			}()
-			next.ServeHTTP(w, r)
-		})
-	}
-
-	h := stampede.Handler(512, 1*time.Second)
-
-	ts := httptest.NewServer(counter(recoverer(h(http.HandlerFunc(app)))))
-	defer ts.Close()
-
-	var wg sync.WaitGroup
-
-	for i := 0; i < numRequests; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			resp, err := http.Get(ts.URL)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer resp.Body.Close()
-
-			// log.Println("got resp:", resp, "len:", len(body), "body:", string(body))
-
-			if string(body) != string(expectedBody) {
-				t.Error("expecting response body:", string(expectedBody))
-			}
-
-			if resp.StatusCode != expectedStatus {
-				t.Error("expecting response status:", expectedStatus)
-			}
-
-			assert.Equal(t, "test", resp.Header.Get("X-Httpjoin"), "expecting x-httpjoin test header")
-		}()
-	}
-
-	wg.Wait()
-
-	totalHits := atomic.LoadUint32(&hits)
-	// if totalHits > 1 {
-	// 	t.Error("handler was hit more than once. hits:", totalHits)
-	// }
-	log.Println("total hits:", totalHits)
-
-	finalCount := atomic.LoadUint32(&count)
-	if finalCount > 0 {
-		t.Error("queue count was expected to be empty, but count:", finalCount)
-	}
-	log.Println("final count:", finalCount)
-}
-
-func TestHash(t *testing.T) {
-	h1 := stampede.BytesToHash([]byte{1, 2, 3})
-	assert.Equal(t, uint64(8376154270085342629), h1)
-
-	h2 := stampede.StringToHash("123")
-	assert.Equal(t, uint64(4353148100880623749), h2)
-}
-
-func TestIssue6_BypassCORSHeaders(t *testing.T) {
-	var expectedStatus int = 200
-	var expectedBody = []byte("hi")
-
-	var count uint64
-
-	domains := []string{
-		"google.com",
-		"sequence.build",
-		"horizon.io",
-		"github.com",
-		"ethereum.org",
-	}
-
-	app := func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Another-Header", "wakka")
-		w.WriteHeader(expectedStatus)
-		w.Write(expectedBody)
-
-		atomic.AddUint64(&count, 1)
-	}
-
-	h := stampede.Handler(512, 1*time.Second)
-	c := cors.New(cors.Options{
-		AllowedOrigins: domains,
-		AllowedMethods: []string{"GET"},
-		AllowedHeaders: []string{"*"},
-	}).Handler
-
-	ts := httptest.NewServer(c(h(http.HandlerFunc(app))))
-	defer ts.Close()
-
-	var wg sync.WaitGroup
-	var domainsHit = map[string]bool{}
-
-	for _, domain := range domains {
-		wg.Add(1)
-		go func(domain string) {
-			defer wg.Done()
-
-			req, err := http.NewRequest("GET", ts.URL, nil)
-			assert.NoError(t, err)
-			req.Header.Set("Origin", domain)
-
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer resp.Body.Close()
-
-			if string(body) != string(expectedBody) {
-				t.Error("expecting response body:", string(expectedBody))
-			}
-
-			if resp.StatusCode != expectedStatus {
-				t.Error("expecting response status:", expectedStatus)
-			}
-
-			domainsHit[resp.Header.Get("Access-Control-Allow-Origin")] = true
-
-			assert.Equal(t, "wakka", resp.Header.Get("X-Another-Header"))
-
-		}(domain)
-	}
-
-	wg.Wait()
-
-	// expect all domains to be returned and recorded in domainsHit
-	for _, domain := range domains {
-		assert.True(t, domainsHit[domain])
-	}
-
-	// expect to have only one actual hit
-	assert.Equal(t, uint64(1), count)
-}
+//
+//import (
+//	"context"
+//	"io/ioutil"
+//	"log"
+//	"net/http"
+//	"net/http/httptest"
+//	"runtime"
+//	"sync"
+//	"sync/atomic"
+//	"testing"
+//	"time"
+//
+//	"github.com/go-chi/cors"
+//	"github.com/go-chi/stampede"
+//	"github.com/stretchr/testify/assert"
+//)
+//
+//func TestGet(t *testing.T) {
+//	var count uint64
+//	cache := stampede.NewCache(512, time.Duration(2*time.Second), time.Duration(5*time.Second))
+//
+//	// repeat test multiple times
+//	for x := 0; x < 5; x++ {
+//		// time.Sleep(1 * time.Second)
+//
+//		var wg sync.WaitGroup
+//		numGoroutines := runtime.NumGoroutine()
+//
+//		n := 10
+//		ctx := context.Background()
+//
+//		for i := 0; i < n; i++ {
+//			t.Logf("numGoroutines now %d", runtime.NumGoroutine())
+//
+//			wg.Add(1)
+//			go func() {
+//				defer wg.Done()
+//
+//				val, err := cache.Get(ctx, "t1", func(ctx context.Context) (interface{}, error) {
+//					t.Log("cache.Get(t1, ...)")
+//
+//					// some extensive op..
+//					time.Sleep(2 * time.Second)
+//					atomic.AddUint64(&count, 1)
+//
+//					return "result1", nil
+//				})
+//
+//				assert.NoError(t, err)
+//				assert.Equal(t, "result1", val)
+//			}()
+//		}
+//
+//		wg.Wait()
+//
+//		// ensure single call
+//		assert.Equal(t, uint64(1), count)
+//
+//		// confirm same before/after num of goroutines
+//		t.Logf("numGoroutines now %d", runtime.NumGoroutine())
+//		assert.Equal(t, numGoroutines, runtime.NumGoroutine())
+//
+//	}
+//}
+//
+//func TestHandler(t *testing.T) {
+//	var numRequests = 30
+//
+//	var hits uint32
+//	var expectedStatus int = 201
+//	var expectedBody = []byte("hi")
+//
+//	app := func(w http.ResponseWriter, r *http.Request) {
+//		// log.Println("app handler..")
+//
+//		atomic.AddUint32(&hits, 1)
+//
+//		hitsNow := atomic.LoadUint32(&hits)
+//		if hitsNow > 1 {
+//			// panic("uh oh")
+//		}
+//
+//		// time.Sleep(100 * time.Millisecond) // slow handler
+//		w.Header().Set("X-Httpjoin", "test")
+//		w.WriteHeader(expectedStatus)
+//		w.Write(expectedBody)
+//	}
+//
+//	var count uint32
+//	counter := func(next http.Handler) http.Handler {
+//		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//			atomic.AddUint32(&count, 1)
+//			next.ServeHTTP(w, r)
+//			atomic.AddUint32(&count, ^uint32(0))
+//			// log.Println("COUNT:", atomic.LoadUint32(&count))
+//		})
+//	}
+//
+//	recoverer := func(next http.Handler) http.Handler {
+//		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//			defer func() {
+//				if r := recover(); r != nil {
+//					log.Println("recovered panicing request:", r)
+//				}
+//			}()
+//			next.ServeHTTP(w, r)
+//		})
+//	}
+//
+//	h := stampede.Handler(512, 1*time.Second)
+//
+//	ts := httptest.NewServer(counter(recoverer(h(http.HandlerFunc(app)))))
+//	defer ts.Close()
+//
+//	var wg sync.WaitGroup
+//
+//	for i := 0; i < numRequests; i++ {
+//		wg.Add(1)
+//		go func() {
+//			defer wg.Done()
+//			resp, err := http.Get(ts.URL)
+//			if err != nil {
+//				t.Fatal(err)
+//			}
+//
+//			body, err := ioutil.ReadAll(resp.Body)
+//			if err != nil {
+//				t.Fatal(err)
+//			}
+//			defer resp.Body.Close()
+//
+//			// log.Println("got resp:", resp, "len:", len(body), "body:", string(body))
+//
+//			if string(body) != string(expectedBody) {
+//				t.Error("expecting response body:", string(expectedBody))
+//			}
+//
+//			if resp.StatusCode != expectedStatus {
+//				t.Error("expecting response status:", expectedStatus)
+//			}
+//
+//			assert.Equal(t, "test", resp.Header.Get("X-Httpjoin"), "expecting x-httpjoin test header")
+//		}()
+//	}
+//
+//	wg.Wait()
+//
+//	totalHits := atomic.LoadUint32(&hits)
+//	// if totalHits > 1 {
+//	// 	t.Error("handler was hit more than once. hits:", totalHits)
+//	// }
+//	log.Println("total hits:", totalHits)
+//
+//	finalCount := atomic.LoadUint32(&count)
+//	if finalCount > 0 {
+//		t.Error("queue count was expected to be empty, but count:", finalCount)
+//	}
+//	log.Println("final count:", finalCount)
+//}
+//
+//func TestHash(t *testing.T) {
+//	h1 := stampede.BytesToHash([]byte{1, 2, 3})
+//	assert.Equal(t, uint64(8376154270085342629), h1)
+//
+//	h2 := stampede.StringToHash("123")
+//	assert.Equal(t, uint64(4353148100880623749), h2)
+//}
+//
+//func TestIssue6_BypassCORSHeaders(t *testing.T) {
+//	var expectedStatus int = 200
+//	var expectedBody = []byte("hi")
+//
+//	var count uint64
+//
+//	domains := []string{
+//		"google.com",
+//		"sequence.build",
+//		"horizon.io",
+//		"github.com",
+//		"ethereum.org",
+//	}
+//
+//	app := func(w http.ResponseWriter, r *http.Request) {
+//		w.Header().Set("X-Another-Header", "wakka")
+//		w.WriteHeader(expectedStatus)
+//		w.Write(expectedBody)
+//
+//		atomic.AddUint64(&count, 1)
+//	}
+//
+//	h := stampede.Handler(512, 1*time.Second)
+//	c := cors.New(cors.Options{
+//		AllowedOrigins: domains,
+//		AllowedMethods: []string{"GET"},
+//		AllowedHeaders: []string{"*"},
+//	}).Handler
+//
+//	ts := httptest.NewServer(c(h(http.HandlerFunc(app))))
+//	defer ts.Close()
+//
+//	var wg sync.WaitGroup
+//	var domainsHit = map[string]bool{}
+//
+//	for _, domain := range domains {
+//		wg.Add(1)
+//		go func(domain string) {
+//			defer wg.Done()
+//
+//			req, err := http.NewRequest("GET", ts.URL, nil)
+//			assert.NoError(t, err)
+//			req.Header.Set("Origin", domain)
+//
+//			resp, err := http.DefaultClient.Do(req)
+//			if err != nil {
+//				t.Fatal(err)
+//			}
+//
+//			body, err := ioutil.ReadAll(resp.Body)
+//			if err != nil {
+//				t.Fatal(err)
+//			}
+//			defer resp.Body.Close()
+//
+//			if string(body) != string(expectedBody) {
+//				t.Error("expecting response body:", string(expectedBody))
+//			}
+//
+//			if resp.StatusCode != expectedStatus {
+//				t.Error("expecting response status:", expectedStatus)
+//			}
+//
+//			domainsHit[resp.Header.Get("Access-Control-Allow-Origin")] = true
+//
+//			assert.Equal(t, "wakka", resp.Header.Get("X-Another-Header"))
+//
+//		}(domain)
+//	}
+//
+//	wg.Wait()
+//
+//	// expect all domains to be returned and recorded in domainsHit
+//	for _, domain := range domains {
+//		assert.True(t, domainsHit[domain])
+//	}
+//
+//	// expect to have only one actual hit
+//	assert.Equal(t, uint64(1), count)
+//}


### PR DESCRIPTION
After custom keyFunction became used, a problem with a memory leak got out,

Since keyFunc is generally user dependent, this behavior contributes to a large amount of data in the cache storage.
This is a memory leak with no way to clean up. PR is illustrate it (`stampede_leak_test.go`)

Custom keyFunc — very important feature for lib users. 

I can take care of the fix. What do you think? 